### PR TITLE
Fix: Check if apk already exists in present_vers before trying to access it

### DIFF
--- a/src/ReVancedBuilder/APKPure_dl.py
+++ b/src/ReVancedBuilder/APKPure_dl.py
@@ -139,7 +139,7 @@ def get_apks(appstate):
 
             print(f"Chosen required version of {apk} is {required_ver}.")
 
-        if appstate['present_vers'][apk] == required_ver:
+        if apk in appstate['present_vers'] and appstate['present_vers'][apk] == required_ver:
             print("It's already present on disk, so skipping download.")
         else:
             apkpure_dl(apk, apkpure_appname, required_ver,


### PR DESCRIPTION
I got an error when I tried to build the non-root ReVanced apk from a clean state.
If I don't have the Youtube APK already in the work directory, then the `present_vers` dictionary does not contain the apk's name and it throws an exception on line 142 in `APKPure_dl.py` file:

```
Started building ReVanced apps at 27 April, 2024 15:26:50
----------------------------------------------------------------------
Checking updates for revanced-cli...
revanced-cli has an update (0 -> 4.6.0)
Downloading revanced-cli.jar...
Done!
Checking updates for revanced-integrations...
revanced-integrations has an update (0 -> 1.8.0)
Downloading revanced-integrations.apk...
Done!
Checking updates for revanced-patches...
revanced-patches has an update (0 -> 4.7.0)
Downloading revanced-patches.jar...
Done!
Checking updates for GmsCore...
GmsCore has an update (0 -> 0.3.1.4.240913)
Downloading GmsCore...
Done!
Downloading required apk files from APKPure...
Checking YouTube...
Chosen required version of com.google.android.youtube is 19.11.43.
Traceback (most recent call last):
  File "/home/adam/Documents/Projects/Python/ReVancedBuilder/./venv/bin/ReVancedBuilder", line 5, in <module>
    from ReVancedBuilder import ReVancedBuilder
  File "/home/adam/Documents/Projects/Python/ReVancedBuilder/src/ReVancedBuilder/ReVancedBuilder.py", line 180, in <module>
    appstate = get_apks(appstate)
               ^^^^^^^^^^^^^^^^^^
  File "/home/adam/Documents/Projects/Python/ReVancedBuilder/src/ReVancedBuilder/APKPure_dl.py", line 142, in get_apks
    if appstate['present_vers'][apk] == required_ver:
       ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^
KeyError: 'com.google.android.youtube'
```

I modified the if statement to check if `apk` is already present in the `present_vers` dict and it fixes the issue.